### PR TITLE
Added All Files (*.*) to file open

### DIFF
--- a/hdf5view/mainwindow.py
+++ b/hdf5view/mainwindow.py
@@ -320,7 +320,7 @@ class MainWindow(QMainWindow):
             self,
             'QFileDialog.getOpenFileName()',
             '',
-            'HDF5 Files (*.hdf *.h5 *.hdf5)',
+            'HDF5 Files (*.hdf *.h5 *.hdf5);; All Files (*.*)',
             options=options
         )
 


### PR DESCRIPTION
Thanks very much for hdf5view - it's very useful!

In my case, some of the hdf5 files I use may have other file extensions than (\*.hdf5, \*.h5) so 
I added All Files (\*.\*) to the file open protocol which allows the user to open these too. 
Non hdf5 files cause an error message if you try to open them but the error
message can be confirmed and you can continue to use the program.

Hope this small PR might be useful.