### PR TITLE
Allow the editing of attributes for a node.

### DIFF
--- a/src/hdf5view/mainwindow.py
+++ b/src/hdf5view/mainwindow.py
@@ -242,7 +242,7 @@ class MainWindow(QMainWindow):
         Open a hdf5 file
         """
         try:
-            hdf = h5py.File(filename, 'r')
+            hdf = h5py.File(filename, 'a')
         except OSError as e:
             hdf = None
             QMessageBox.critical(


### PR DESCRIPTION
I am currently working on instrument control using python, and I have adapted ``hdf5view`` to work with an hdf5 file hosted on a server [viewer](https://github.com/mawenzy/p5control/blob/main/viewer.py). For this, I have extended the functionality, including editing of attributes. This pull request adds the ability to edit the attributes.

Changes:

- updated ``AttributesTableModel`` to allow for the editing of the Attributes, including changing the key and the type
    - currently ``str``, ``int`` and ``float`` are supported types 
- added new widget ``ExtendableAttributesTableView``, which extends the ``QTableView`` of the ``AttributesTableModel`` by adding buttons to remove and add new attribute entries.
- ``h5py.File`` is now opened in mode ``"a"`` to allow editing the attributes

Testes with pyside6.